### PR TITLE
Update PacketHandlerModern.java

### DIFF
--- a/Loader - Bukkit/src/me/devtec/theapi/bukkit/packetlistener/PacketHandlerModern.java
+++ b/Loader - Bukkit/src/me/devtec/theapi/bukkit/packetlistener/PacketHandlerModern.java
@@ -73,6 +73,9 @@ public class PacketHandlerModern implements PacketHandler<Channel> {
 				hasTicked = "ac";
 				break;
 			}
+			case 20:
+				hasTicked = "ad";
+				break;
 			while (!(boolean) Ref.get(BukkitLoader.getNmsProvider().getMinecraftServer(), hasTicked))
 				try {
 					Thread.sleep(20);


### PR DESCRIPTION
Adding new 1.20 - 1.20.1 field because of Minecraft obfuscation  Old 1.19.x-1.19.4 uses field "ac" for field to determine whether the server is actually being setup but in 1.20.x it's different field beacuse of the obfuscation. 

And because there wasn't any `case 20:`, the while loop never actually ended thus never being able to reach the Packet Handler setup part. 

This change fixes that.

1.19
![image](https://github.com/TheDevTec/TheAPI/assets/51047364/ae72ef59-b399-48e9-88bc-c29bc89d940b)

1.20
![image](https://github.com/TheDevTec/TheAPI/assets/51047364/1435e4fb-1b83-49ac-88d5-a3a90a57df6d)
